### PR TITLE
Use autosized textarea instead of input text box. Resolves #16

### DIFF
--- a/src/views/sessions/SessionOrder.vue
+++ b/src/views/sessions/SessionOrder.vue
@@ -75,8 +75,9 @@
                  :groupRowsBy="order.group_by_category ? 'category' : null">
         <Column field="name" header="Product" body-class="form-cell" style="width: 80%">
           <template #body="{ data }">
-            <InputText :value="data.name" @change="data.name = $event.target.value"
-                       class="text-start" />
+            <Textarea :value="data.name" :autoResize="true" rows="1"
+                      @change="data.name = $event.target.value"
+                      class="border-0" style="width: 99%" />
           </template>
         </Column>
         <Column field="value" header="Amount" class="text-center" body-class="form-cell">

--- a/src/views/sessions/SessionOrder.vue
+++ b/src/views/sessions/SessionOrder.vue
@@ -77,7 +77,7 @@
           <template #body="{ data }">
             <Textarea :value="data.name" :autoResize="true" rows="1"
                       @change="data.name = $event.target.value"
-                      class="border-0" style="width: 99%" />
+                      class="product-textarea" />
           </template>
         </Column>
         <Column field="value" header="Amount" class="text-center" body-class="form-cell">
@@ -328,6 +328,16 @@ export default {
   background-color: transparent;
 }
 
+.product-textarea {
+  border: none;
+  border-radius: 0;
+  width: 99%;
+
+  &:focus {
+    border: 1px solid black;
+  }
+}
+
 @media print {
   .session-order {
     max-width: 600px;
@@ -340,7 +350,7 @@ export default {
 
   .p-inputtextarea {
     border: none;
-    padding: 0px;
+    padding: 10px;
     margin-bottom: 0 !important;
     font-weight: 500;
   }

--- a/src/views/sessions/SessionOrder.vue
+++ b/src/views/sessions/SessionOrder.vue
@@ -350,9 +350,13 @@ export default {
 
   .p-inputtextarea {
     border: none;
-    padding: 10px;
+    padding: 0px;
     margin-bottom: 0 !important;
     font-weight: 500;
+  }
+
+  table .p-inputtextarea {
+    padding: 10px;
   }
 }
 </style>


### PR DESCRIPTION
Used Textarea component from PrimeVue to resolve the issue

Used style `{width: 99%}` for aesthetic reason 
because at 100% the border which appears when the Textarea component is selected 
overlaps the border of the amount InputText  

<img width="1066" alt="Capture d’écran 2024-10-13 à 13 35 32" src="https://github.com/user-attachments/assets/68c1f745-fce3-4c6b-9a7c-f6dcd5b70eec">

<img width="1066" alt="Capture d’écran 2024-10-13 à 13 36 13" src="https://github.com/user-attachments/assets/5331d652-b03b-4887-8318-15ec378af9fe">
